### PR TITLE
Define _DEFAULT_SOURCE to avoid _BSD_SOURCE deprecation warning.

### DIFF
--- a/lib/unix_unistd_stubs.c
+++ b/lib/unix_unistd_stubs.c
@@ -15,6 +15,7 @@
  *
  */
 
+#define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 #define _XOPEN_SOURCE 600
 #define _GNU_SOURCE // includes the previous feature macros on Linux


### PR DESCRIPTION
The build fails for me with glibc 2.21-6, like this:

```
In file included from /usr/include/stdint.h:25:0,
                 from /usr/lib/gcc/x86_64-linux-gnu/5/include/stdint.h:9,
                 from lib/unix_unistd_stubs.c:22:
/usr/include/features.h:148:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^
cc1: all warnings being treated as errors
```

The comment in `features.h` suggests that `#define`ing both `_BSD_SOURCE` and `_DEFAULT_SOURCE` is acceptable for the moment:

```
/* _BSD_SOURCE and _SVID_SOURCE are deprecated aliases for
   _DEFAULT_SOURCE.  If _DEFAULT_SOURCE is present we do not
   issue a warning; the expectation is that the source is being
   transitioned to use the new macro.  */
```
