### PR TITLE
Switch to unix-errno 0.4.0

### DIFF
--- a/opam
+++ b/opam
@@ -27,4 +27,5 @@ depopts: [
 conflicts: [
   "lwt" {< "2.5.0"}
   "ctypes" {< "0.4.0"}
+  "unix-errno" { < "0.4.0" }
 ]


### PR DESCRIPTION
`Errno_unix.raise_on_errno` [now returns an `option`](https://github.com/dsheets/ocaml-unix-errno/blob/0.4.0/unix/errno_unix.mli#L45-L48).