### PR TITLE
Lwt: allow passing ?set_flags to I/O functions

### DIFF
--- a/lwt/unistd_unix_lwt.ml
+++ b/lwt/unistd_unix_lwt.ml
@@ -27,14 +27,15 @@ let char_bigarray_of_unit_ptr p len =
   bigarray_of_ptr array1 len Bigarray.char
     (coerce (ptr void) (ptr char) p)
 
-let write ?blocking fd ptr len =
-  let lwt_fd = Lwt_unix.of_unix_file_descr ?blocking fd in
+let write ?blocking ?set_flags fd ptr len =
+  let lwt_fd = Lwt_unix.of_unix_file_descr ?blocking ?set_flags fd in
   Lwt_bytes.write lwt_fd (char_bigarray_of_unit_ptr ptr len) 0 len
 
 open Posix_types
 
-let pwrite ?blocking fd (Ctypes_static.CPointer ptr as p) len offset =
-  let lwt_fd = Lwt_unix.of_unix_file_descr ?blocking fd in
+let pwrite
+    ?blocking ?set_flags fd (Ctypes_static.CPointer ptr as p) len offset =
+  let lwt_fd = Lwt_unix.of_unix_file_descr ?blocking ?set_flags fd in
   Lwt_unix.blocking lwt_fd >>= function
   | true ->
     Lwt_unix.wait_write lwt_fd >>= fun () ->
@@ -46,12 +47,12 @@ let pwrite ?blocking fd (Ctypes_static.CPointer ptr as p) len offset =
     Lwt_unix.(wrap_syscall Write) lwt_fd @@ fun () ->
     Unistd_unix.pwrite fd p len offset
 
-let read ?blocking fd ptr len =
-  let lwt_fd = Lwt_unix.of_unix_file_descr ?blocking fd in
+let read ?blocking ?set_flags fd ptr len =
+  let lwt_fd = Lwt_unix.of_unix_file_descr ?blocking ?set_flags fd in
   Lwt_bytes.read lwt_fd (char_bigarray_of_unit_ptr ptr len) 0 len
 
-let pread ?blocking fd (Ctypes_static.CPointer ptr as p) len offset =
-  let lwt_fd = Lwt_unix.of_unix_file_descr ?blocking fd in
+let pread ?blocking ?set_flags fd (Ctypes_static.CPointer ptr as p) len offset =
+  let lwt_fd = Lwt_unix.of_unix_file_descr ?blocking ?set_flags fd in
   Lwt_unix.blocking lwt_fd >>= function
   | true ->
     Lwt_unix.wait_read lwt_fd >>= fun () ->

--- a/lwt/unistd_unix_lwt.mli
+++ b/lwt/unistd_unix_lwt.mli
@@ -16,17 +16,17 @@
  *)
 
 (** Can raise Unix.Unix_error *)
-val write : ?blocking:bool ->
+val write : ?blocking:bool -> ?set_flags:bool ->
   Unix.file_descr -> unit Ctypes.ptr -> int -> int Lwt.t
 
 (** Can raise Unix.Unix_error *)
-val pwrite : ?blocking:bool ->
+val pwrite : ?blocking:bool -> ?set_flags:bool ->
   Unix.file_descr -> unit Ctypes.ptr -> int -> int64 -> int Lwt.t
 
 (** Can raise Unix.Unix_error *)
-val read : ?blocking:bool ->
+val read : ?blocking:bool -> ?set_flags:bool ->
   Unix.file_descr -> unit Ctypes.ptr -> int -> int Lwt.t
 
 (** Can raise Unix.Unix_error *)
-val pread : ?blocking:bool ->
+val pread : ?blocking:bool -> ?set_flags:bool ->
   Unix.file_descr -> unit Ctypes.ptr -> int -> int64 -> int Lwt.t


### PR DESCRIPTION
...which then pass it to `Lwt_unix.of_unix_file_descr`.

I think the API itself probably needs to be changed, probably to take `Lwt_unix.file_descr` instead of `Unix.file_descr`. I chose a simpler, non-breaking patch for now.